### PR TITLE
docs(skills): standardize skill formatting and correctness

### DIFF
--- a/skills/actions/agent/learn-this/SKILL.md
+++ b/skills/actions/agent/learn-this/SKILL.md
@@ -9,60 +9,60 @@ metadata:
 
 # Learn the Project
 
-- Read the **documentation, code, configurations, Makefiles, tests, and other relevant files**.  
-- Do not assume documentation is complete or accurate — verify by examining the actual code.  
-- Develop a solid understanding of the **architecture, goals, and key components**.  
-- Take note of **design patterns, dependencies, and conventions** that shape the project.  
+- Read the **documentation, code, configurations, Makefiles, tests, and other relevant files**.
+- Do not assume documentation is complete or accurate — verify by examining the actual code.
+- Develop a solid understanding of the **architecture, goals, and key components**.
+- Take note of **design patterns, dependencies, and conventions** that shape the project.
 
 ## Learning Objectives
-- **Purpose & Goals**  
-  - What is the project for?  
-  - What problem(s) does it solve?  
-  - Who is the intended audience or user?  
+- **Purpose & Goals**
+  - What is the project for?
+  - What problem(s) does it solve?
+  - Who is the intended audience or user?
 
-- **Main Features**  
-  - Core functionality and modules.  
-  - Special or standout features.  
-  - What differentiates it from alternatives?  
+- **Main Features**
+  - Core functionality and modules.
+  - Special or standout features.
+  - What differentiates it from alternatives?
 
-- **Technologies & Frameworks**  
-  - Languages, libraries, frameworks, and tools in use.  
-  - External dependencies (databases, queues, services, etc.).  
-  - Build/test infrastructure (Makefiles, CI/CD, etc.).  
+- **Technologies & Frameworks**
+  - Languages, libraries, frameworks, and tools in use.
+  - External dependencies (databases, queues, services, etc.).
+  - Build/test infrastructure (Makefiles, CI/CD, etc.).
 
-- **Architecture & Design**  
-  - Overall architecture (monolith, microservices, layered, event-driven, etc.).  
-  - Key components and how they interact.  
-  - Important **architectural decisions** and trade-offs.  
-  - Scalability, extensibility, and testability considerations.  
+- **Architecture & Design**
+  - Overall architecture (monolith, microservices, layered, event-driven, etc.).
+  - Key components and how they interact.
+  - Important **architectural decisions** and trade-offs.
+  - Scalability, extensibility, and testability considerations.
 
-- **Maintainability & Resiliency (from reviewing prompts)**  
-  - Is the project documented and easy to navigate?  
-  - How resilient is the design to failures?  
-  - Are tests and error-handling approaches visible?  
+- **Maintainability & Resiliency (from reviewing prompts)**
+  - Is the project documented and easy to navigate?
+  - How resilient is the design to failures?
+  - Are tests and error-handling approaches visible?
 
 ## Output Format
-1. **Project Summary**  
-   - Purpose, goals, and audience.  
-   - Main features.  
+1. **Project Summary**
+   - Purpose, goals, and audience.
+   - Main features.
 
-2. **Technologies & Frameworks**  
-   - Languages, libraries, build/test tools, dependencies.  
+2. **Technologies & Frameworks**
+   - Languages, libraries, build/test tools, dependencies.
 
-3. **Architecture & Design**  
-   - Key components and their interactions.  
-   - Important design decisions.  
+3. **Architecture & Design**
+   - Key components and their interactions.
+   - Important design decisions.
 
-4. **Maintainability & Resiliency Notes**  
-   - Documentation completeness.  
-   - Evidence of test coverage and error handling.  
+4. **Maintainability & Resiliency Notes**
+   - Documentation completeness.
+   - Evidence of test coverage and error handling.
 
-5. **Checklist** (✅/⚠️/❌)  
-   - Purpose & goals defined  
-   - Main features identified  
-   - Tech stack clear  
-   - Architecture understood  
-   - Maintainability/resiliency noted  
+5. **Checklist** (✅/⚠️/❌)
+   - Purpose & goals defined
+   - Main features identified
+   - Tech stack clear
+   - Architecture understood
+   - Maintainability/resiliency noted
 
-6. **Additional Insights**  
-   - Anything unusual, risky, or particularly well done.  
+6. **Additional Insights**
+   - Anything unusual, risky, or particularly well done.

--- a/skills/actions/agent/learn-this/SKILL.md
+++ b/skills/actions/agent/learn-this/SKILL.md
@@ -7,8 +7,6 @@ metadata:
   version: "1.0"
 ---
 
-# learn-this
-
 # Learn the Project
 
 - Read the **documentation, code, configurations, Makefiles, tests, and other relevant files**.  

--- a/skills/actions/docs/init-readme/SKILL.md
+++ b/skills/actions/docs/init-readme/SKILL.md
@@ -8,9 +8,7 @@ metadata:
   version: "1.0"
 ---
 
-# init-readme
-```markdown
-# Prompt: Generate a Polished README for Any Project
+# Create a Polished README.md for Any Project
 
 ## Goal
 Produce a high-quality `README.md`:
@@ -67,6 +65,7 @@ Keep it accurate (no hallucinations), concise, and developer-friendly.
 - **Getting Started**:
   - *Library*: install/import + minimum example
   - *CLI*: install + first command + basic usage
+  - *Service*: install + how to run + basic API call
 - **Structure**: key packages/modules with short descriptions + doc links
 - **Closing**: short call for feedback/PRs
 
@@ -74,6 +73,7 @@ Keep it accurate (no hallucinations), concise, and developer-friendly.
 
 ## Output Format (write exactly this structure)
 
+```markdown
 # <ProjectName> <optional emoji>
 <optional logo image, if found>
 
@@ -167,9 +167,10 @@ PRs welcome! Please see `CONTRIBUTING.md` (if present) and open an issue for dis
 
 ---
 
-## 🌴 Stay <Project Vibe>!
+## <Emoji + Project Vibe>!
 
 \<Short, friendly sign-off encouraging issues/PRs. One tasteful emoji.>
+```
 
 ---
 
@@ -207,4 +208,3 @@ If any badge cannot be resolved confidently, **omit it**.
 6. Assemble the README using the **Output Format**.
 7. Validate links (badge URLs, docs references) exist; remove any broken ones.
 8. Output final Markdown only (no extra commentary).
-```

--- a/skills/actions/git/commit/SKILL.md
+++ b/skills/actions/git/commit/SKILL.md
@@ -10,9 +10,9 @@ metadata:
 
 # Perform a Git Commit for Staged Changes
 
-## Tooling:
+## Tooling
 
-### Viewing Staged Changes:
+### Viewing Staged Changes
 
 Use:
 
@@ -26,7 +26,7 @@ If changes are not staged, ask the user to stage them or if they want to stage a
 git add .
 ```
 
-### Committing Changes:
+### Committing Changes
 
 Commit non-interactively by reading the message from stdin (safe with `!`, quotes, backticks, and newlines):
 
@@ -43,19 +43,13 @@ Avoid passing commit messages via `-m` when the message may contain `!`, quotes,
 ## Rules
 
 - If change is trivial (e.g., <100 lines changed, small edits), generate a single-line commit.
-
 - If change is non-trivial, allow a concise multi-line commit.
-
 - Always follow Conventional Commits format including adding issues, user stories, tasks, or defects references if available.
-
 - Limit subject line to 100 characters max.
 
 ## Style
 
 - Never start with an emoji; one emoji at the end of the subject is OK.
-
 - Add a touch of contextual humor (just enough for a chuckle, but still relevant and professional).
-
 - Title/subject: optionally append a single emoji at the end; Body: keep total emojis subtle (generally ≤2).
-
 - If you’re forced to inline a message in a shell command, avoid shell-problematic characters (especially `!`). Otherwise prefer the stdin-based commit flow above.

--- a/skills/actions/git/commit/SKILL.md
+++ b/skills/actions/git/commit/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   version: "1.0"
 ---
 
-# commit
-
 # Perform a Git Commit for Staged Changes
 
 ## Tooling:
@@ -17,12 +15,21 @@ metadata:
 ### Viewing Staged Changes:
 
 Use:
+
 ```bash
 git --no-pager diff --staged
 ```
+
+If changes are not staged, ask the user to stage them or if they want to stage all changes with:
+
+```bash
+git add .
+```
+
 ### Committing Changes:
 
 Commit non-interactively by reading the message from stdin (safe with `!`, quotes, backticks, and newlines):
+
 ```bash
 git commit -F - <<'EOF'
 <type(scope): subject>
@@ -30,6 +37,7 @@ git commit -F - <<'EOF'
 <body (optional)>
 EOF
 ```
+
 Avoid passing commit messages via `-m` when the message may contain `!`, quotes, backticks, backslashes, or newlines.
 
 ## Rules

--- a/skills/actions/git/open-pr/SKILL.md
+++ b/skills/actions/git/open-pr/SKILL.md
@@ -8,9 +8,22 @@ metadata:
   version: "1.0"
 ---
 
-# open-pr
-
 # Create a Pull Request for Current Branch
+
+Review changes on the current branch and open a pull request using GitHub CLI (`gh`).
+This skill is useful when the user asks to open/create a PR, prepare a PR title/body, or summarize changes for review.
+
+## Review Git State
+
+- Show remotes:
+```bash
+git remote -v
+```
+
+- Show current branch:
+```bash
+git rev-parse --abrev-ref HEAD
+```
 
 ## Review Changes
 
@@ -21,6 +34,7 @@ Use the upstream base if set; otherwise fall back to `origin/main`.
 git --no-pager log --oneline --decorate --no-merges \
   "$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo origin/main)..HEAD"
 ```
+
 - Show diff summary (files/lines changed):
 ```bash
 git --no-pager diff --stat \
@@ -60,4 +74,4 @@ EOF
 
 - Title: Use Conventional Commits `type(scope): subject`; ≤100 chars; no leading emoji; optional one emoji at the end.
 - Description: Summarize what changed and why; include risk/impact as bullets.
-- Style: Professional, concise; at most 1 emoji in title and ≤2 in body.
+- Style: Professional, a bit lighthearted, concise; at most 1 emoji in title and ≤2 in body.

--- a/skills/actions/git/open-pr/SKILL.md
+++ b/skills/actions/git/open-pr/SKILL.md
@@ -22,7 +22,7 @@ git remote -v
 
 - Show current branch:
 ```bash
-git rev-parse --abrev-ref HEAD
+git rev-parse --abbrev-ref HEAD
 ```
 
 ## Review Changes
@@ -40,6 +40,7 @@ git --no-pager log --oneline --decorate --no-merges \
 git --no-pager diff --stat \
   "$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo origin/main)..HEAD"
 ```
+
 ## Create the PR
 
 Some agent environments are sandboxed and may not allow writing to `/tmp`. Prefer piping the PR body over stdin using `--body-file -`.

--- a/skills/actions/go/gen-godocs/SKILL.md
+++ b/skills/actions/go/gen-godocs/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   version: "1.0"
 ---
 
-# gen-godocs
-
 # Prompt: Generate Godoc Comments
 
 ## Goal
@@ -188,6 +186,6 @@ const (
 ## Quality Gates
 
 * **100% documentation coverage** for packages and top-level exported API.
-* Unexported declarations documented unless intentionally private noise—prefer brief one-liners.
+* Unexported declarations should also be documented where it adds clarity, especially for complex logic or non-obvious behavior.
 * First sentence present tense, ends with a period.
 * No trailing whitespace; `gofmt` clean.

--- a/skills/actions/go/review-godocs/SKILL.md
+++ b/skills/actions/go/review-godocs/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   version: "1.0"
 ---
 
-# review-godocs
-
 # Prompt: Review Godoc Comments
 
 ## Goal

--- a/skills/actions/review/review-this/SKILL.md
+++ b/skills/actions/review/review-this/SKILL.md
@@ -7,8 +7,6 @@ metadata:
   version: "1.0"
 ---
 
-# review-this
-
 # Review Code or Documentation
 
 - Familiarize yourself with the project or item (code, docs, or related files).

--- a/skills/knowledge/go/go-style-guide/SKILL.md
+++ b/skills/knowledge/go/go-style-guide/SKILL.md
@@ -254,23 +254,23 @@ Use when:
 
 Use these supporting documents when deeper detail is needed:
 
-- [references/LOGGING.md](references/LOGGING.md)  
+- [references/LOGGING.md](references/LOGGING.md)
   Logging rules: default “no logging in packages,” exceptions, slog injection.
 
-- [references/ERRORS.md](references/ERRORS.md)  
+- [references/ERRORS.md](references/ERRORS.md)
   Sentinel-first error design, wrapping rules, errors.Is/As contracts.
 
-- [references/CONFIG.md](references/CONFIG.md)  
+- [references/CONFIG.md](references/CONFIG.md)
   Canonical Config struct patterns, constructor validation + defaults.
 
-- [references/INTERFACES.md](references/INTERFACES.md)  
+- [references/INTERFACES.md](references/INTERFACES.md)
   Interface boundaries, driver patterns, testability-first design.
 
-- [references/LAYOUT.md](references/LAYOUT.md)  
+- [references/LAYOUT.md](references/LAYOUT.md)
   File organization, struct field efficiency, package naming guidance.
 
-- [references/BENCHMARKS.md](references/BENCHMARKS.md)  
+- [references/BENCHMARKS.md](references/BENCHMARKS.md)
   Benchmark expectations, templates, performance validation rules.
 
-- [references/REVIEW-CHECKLIST.md](references/REVIEW-CHECKLIST.md)  
-  PR review rubric for human`s and coding agents.
+- [references/REVIEW-CHECKLIST.md](references/REVIEW-CHECKLIST.md)
+  PR review rubric for humans and coding agents.

--- a/skills/knowledge/go/go-style-guide/SKILL.md
+++ b/skills/knowledge/go/go-style-guide/SKILL.md
@@ -117,7 +117,7 @@ Example:
 ```
 cmd/myapp/main.go
 pkg/...
-app/...
+pkg/app/...
 ```
 ### Libraries
 - Packages at top-level directories, or under `pkg/` if it improves clarity for newcomers.
@@ -273,4 +273,4 @@ Use these supporting documents when deeper detail is needed:
   Benchmark expectations, templates, performance validation rules.
 
 - [references/REVIEW-CHECKLIST.md](references/REVIEW-CHECKLIST.md)  
-  PR review rubric for humans and coding agents.
+  PR review rubric for human`s and coding agents.


### PR DESCRIPTION
## Summary
Standardizes SKILL.md formatting and fixes correctness issues across the skills set to improve consistency and reduce command/documentation mistakes.

## Changes
- Removed duplicated top-level skill-name headings and normalized heading punctuation/spacing.
- Fixed `git rev-parse --abbrev-ref` typo and improved wording/style guidance in relevant skills.
- Corrected README skill prompt fencing/structure and aligned Go style guide path/reference text.

## Rationale
These updates make skill docs more uniform and reliable for repeated agent use, while fixing concrete correctness errors that could break command examples.

## Risk & Impact
- Breaking changes: no
- Performance/Security: no runtime impact; docs-only changes
